### PR TITLE
iTunes lookup API can return Array

### DIFF
--- a/lib/itunes-search-api.rb
+++ b/lib/itunes-search-api.rb
@@ -11,9 +11,7 @@ class ITunesSearchAPI
     end
 
     def lookup(query={})
-      if results = get("/lookup", :query => query)["results"]
-        results[0]
-      end
+      get("/lookup", :query => query)["results"]
     end
   end
 end

--- a/spec/itunes-search-api_spec.rb
+++ b/spec/itunes-search-api_spec.rb
@@ -37,13 +37,14 @@ describe ITunesSearchAPI do
 
     it "should return nil if the lookup returns no results" do
       stub_request(:get, LOOKUP_URL).with(:query => {:id => "284910350"}).to_return(:body => fixture("lookup-no-results.json"))
-      ITunesSearchAPI.lookup(:id => "284910350").should be_nil
+      ITunesSearchAPI.lookup(:id => "284910350").should be_empty
     end
 
     it "should return the result if the lookup returns a result" do
       stub_request(:get, LOOKUP_URL).with(:query => {:id => "284910350"}).to_return(:body => fixture("lookup-result.json"))
       result = ITunesSearchAPI.lookup(:id => "284910350")
-      result["artistName"].should == "Jack Johnson"
+      result.class.should eq(Array)
+      result.first["artistName"].should == "Jack Johnson"
     end
   end
 end


### PR DESCRIPTION
There are some cases we want to get result array via iTunes lookup API.

ex)
https://itunes.apple.com/lookup?amgArtistId=468749,5723&entity=album&limit=5
