### PR TITLE
Switch to httpclient gem for handling http requests

### DIFF
--- a/itunes-search-api.gemspec
+++ b/itunes-search-api.gemspec
@@ -21,16 +21,16 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httparty>, [">= 0"])
+      s.add_runtime_dependency(%q<httpclient>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<webmock>, [">= 0"])
     else
-      s.add_dependency(%q<httparty>, [">= 0"])
+      s.add_dependency(%q<httpclient>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<webmock>, [">= 0"])
     end
   else
-    s.add_dependency(%q<httparty>, [">= 0"])
+    s.add_dependency(%q<httpclient>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<webmock>, [">= 0"])
   end

--- a/lib/itunes-search-api.rb
+++ b/lib/itunes-search-api.rb
@@ -1,17 +1,13 @@
-require 'httparty'
+require 'httpclient'
 
 class ITunesSearchAPI
-  include HTTParty
-  base_uri 'https://itunes.apple.com'
-  format :json
-
   class << self
     def search(query={})
-      get("/search", :query => query)["results"]
+      JSON.parse(HTTPClient.new.get("https://itunes.apple.com/search", :query => query).body)["results"]
     end
 
     def lookup(query={})
-      get("/lookup", :query => query)["results"]
+      JSON.parse(HTTPClient.new.get("https://itunes.apple.com/lookup", :query => query).body)["results"]
     end
   end
 end

--- a/spec/itunes-search-api_spec.rb
+++ b/spec/itunes-search-api_spec.rb
@@ -7,7 +7,7 @@ LOOKUP_URL = "#{API_URL}/lookup"
 describe ITunesSearchAPI do
   describe ".search" do
     it "should perform a GET request to /search with the parameters passed" do
-      stub_request(:get, /#{SEARCH_URL}.*/)
+      stub_request(:get, /#{SEARCH_URL}.*/).to_return(:body => fixture("search-no-results.json"))
       ITunesSearchAPI.search(:term => "The Killers")
       WebMock.should have_requested(:get, SEARCH_URL).with(:query => {:term => "The Killers"})
     end
@@ -30,7 +30,7 @@ describe ITunesSearchAPI do
 
   describe ".lookup" do
     it "should perform a GET request to /lookup with the parameters passed" do
-      stub_request(:get, /#{LOOKUP_URL}.*/)
+      stub_request(:get, /#{LOOKUP_URL}.*/).to_return(:body => fixture("lookup-no-results.json"))
       ITunesSearchAPI.lookup(:id => "284910350")
       WebMock.should have_requested(:get, LOOKUP_URL).with(:query => {:id => "284910350"})
     end


### PR DESCRIPTION
Because it has better support for configuring an HTTP proxy by setting the environment variable HTTP_PROXY.
